### PR TITLE
Pin GitHub Actions to commit hashes (STW-1475)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
@@ -37,7 +37,7 @@ jobs:
           CGO_ENABLED: 0
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           files: |
             rewardmanager-linux-amd64


### PR DESCRIPTION
## Summary
- Pin all GitHub Action references to commit SHAs instead of mutable tags
- Mitigates supply chain attack risk from compromised tags
- Inline comments preserve original tag versions for maintainability

## Test plan
- [ ] Verify workflows trigger correctly on push/PR events
- [ ] Confirm no functional changes to workflow behavior

Refs: STW-1475